### PR TITLE
Removido caractere adicional inválido

### DIFF
--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,9 +1,9 @@
 # configura banco in memory H2 ----------------
-spring.jpa.hibernate.ddl-auto=create	
+spring.jpa.hibernate.ddl-auto=create
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
 spring.datasource.username=sa
 spring.datasource.password=sa
 
 # Desabilita Flyway migration
-spring.flyway.enabled=false
+flyway.enabled=false


### PR DESCRIPTION
Um caractere adicionar, provavelmente um espaço em branco estava adicionado após o "create", o que fazia os testes falharem. Também alterei a linha do flyway para desabilita-lo na versão 1.5.